### PR TITLE
Added the set() function for more compact set creation

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,3 +3,5 @@ Revision history for Set-Tiny
 0.01    2009-03-18
         First version, released on an unsuspecting world.
 
+0.02    2014-09-24
+        Added convenience initializer `set`.

--- a/lib/Set/Tiny.pm
+++ b/lib/Set/Tiny.pm
@@ -3,13 +3,26 @@ package Set::Tiny;
 use 5.004;
 use strict;
 
-$Set::Tiny::VERSION = '0.01';
+require Exporter;
+@Set::Tiny::ISA = qw(Exporter);
+@Set::Tiny::EXPORT_OK = qw(set);
+
+$Set::Tiny::VERSION = '0.02';
 
 sub new {
     my $class = shift;
     my %self;
     @self{@_} = ();
     return bless \%self, $class;
+}
+
+sub set {
+    if ( ref( $_[ 0 ] ) ne '' ) {
+        return Set::Tiny->new( @{ $_[ 0 ] } );
+    }
+    else {
+        return Set::Tiny->new(@_);
+    }
 }
 
 sub as_string { "(" . join(" ", sort keys %{$_[0]}) . ")" }
@@ -124,6 +137,10 @@ Version 0.01
 
     print "i is a subset of s1"   if $i->is_subset($s1);
     print "u is a superset of s1" if $u->is_superset($s1);
+
+    # or using the shorter initializer
+    use Set::Tiny qw(set);
+    my $s1 = set(qw(a b c));
 
 =head1 DESCRIPTION
 
@@ -278,6 +295,11 @@ Returns true if this set is a subset of I<set>.
 =head2 is_superset( I<set> )
 
 Returns true if this set is a superset of I<set>.
+
+=head1 EXPORTABLE FUNCTIONS
+
+If you request it, Set::Tiny can export a function C<set()>, which lets you create
+a set in a slightly more compact form.
 
 =head1 AUTHOR
 

--- a/t/set_init.t
+++ b/t/set_init.t
@@ -1,0 +1,17 @@
+#!/usr/bin/perl
+use strict;
+
+use Test::More tests => 5;
+
+# test to make sure that the short initializer (`set()`) works
+
+use_ok 'Set::Tiny', qw(set);
+
+my $a = set();
+my $b = set(qw( a b c ));
+
+isa_ok $a, 'Set::Tiny';
+isa_ok $b, 'Set::Tiny';
+
+is $a->as_string, '()', "empty set stringification";
+is $b->as_string, '(a b c)', "non-empty set stringification";


### PR DESCRIPTION
Hi! I created this as a request on rt.cpan.org a while back, but nothing occurred, so I thought it might be better if I approached you here.

This change adds a function `set()`, which can be exported if requested, that makes a more compact way to create sets. In some of my code, I have a lot of set comparison happening, and I think it makes the code more readable to do something like

```
    set(1, 2, 3)->is_subset(set(1, 2, 3, 4, 5, 6))
```

instead of

```
    Set::Tiny->new(1, 2, 3)->is_subset(Set::Tiny->new(1, 2, 3, 4, 5, 6))
```

This function isn't provided unless explicitly requested, so it doesn't have any effect on existing code use.

Thanks,
Ricky
