### PR TITLE
Update convenience initalizer

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Set-Tiny
 
+0.04    2016-02-22
+        Updated convenience initializer:
+            - If you pass a Set::Tiny, it will return a clone of that Set::Tiny
+            - The test for passing an arrayref is stricter, so it won't do weird things to hashrefs.
+
 0.03    2015-08-26
         Faster intersection. Thanks to Alberto Simões.
 

--- a/lib/Set/Tiny.pm
+++ b/lib/Set/Tiny.pm
@@ -20,7 +20,7 @@ sub set {
 	if (ref($_[0]) eq "Set::Tiny") {
 		return $_[0]->clone();
 	}
-    elsif (ref($_[0]) ne '') {
+    elsif (ref($_[0]) eq 'ARRAY') {
         return Set::Tiny->new(@{$_[0]});
     }
     else {

--- a/lib/Set/Tiny.pm
+++ b/lib/Set/Tiny.pm
@@ -7,7 +7,7 @@ require Exporter;
 @Set::Tiny::ISA = qw(Exporter);
 @Set::Tiny::EXPORT_OK = qw(set);
 
-$Set::Tiny::VERSION = '0.03';
+$Set::Tiny::VERSION = '0.04';
 
 sub new {
     my $class = shift;

--- a/lib/Set/Tiny.pm
+++ b/lib/Set/Tiny.pm
@@ -17,8 +17,8 @@ sub new {
 }
 
 sub set {
-    if ( ref( $_[ 0 ] ) ne '' ) {
-        return Set::Tiny->new( @{ $_[ 0 ] } );
+    if (ref($_[0]) ne '') {
+        return Set::Tiny->new(@{$_[0]});
     }
     else {
         return Set::Tiny->new(@_);

--- a/lib/Set/Tiny.pm
+++ b/lib/Set/Tiny.pm
@@ -17,7 +17,10 @@ sub new {
 }
 
 sub set {
-    if (ref($_[0]) ne '') {
+	if (ref($_[0]) eq "Set::Tiny") {
+		return $_[0]->clone();
+	}
+    elsif (ref($_[0]) ne '') {
         return Set::Tiny->new(@{$_[0]});
     }
     else {
@@ -197,6 +200,9 @@ create a Set::Tiny instance in a more compact form.
 
 Unlike the constructor, this function also accepts the set elements as an array
 reference.
+
+If you pass an existing Set::Tiny to the initializer, it creates a clone of the set
+and returns that.
 
 =head1 METHODS
 

--- a/t/set_init.t
+++ b/t/set_init.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 
-use Test::More tests => 6;
+use Test::More tests => 7;
 
 # test to make sure that the short initializer (`set()`) works
 
@@ -18,3 +18,6 @@ is $b->as_string, '(a b c)', "non-empty set stringification";
 
 my $c = set(['a', 'b', 'c']);
 is $c->as_string, '(a b c)', "initializer can be called with arrayref";
+
+my $d = set($c);
+is $d->as_string, '(a b c)', "initializer can be called on existing set";


### PR DESCRIPTION
Hi! I've made a few changes to the `set()` initializer, which I'm hoping make sense to merge in?
- If you pass an existing Set::Tiny to the initializer, it returns a clone of it
- I fixed the test for passing an arrayref to make it more explicit (so it doesn't do weird things with other objects and hashrefs)

If you prefer that I not change the test, let me know and I'll undo that change.
